### PR TITLE
Renaming of file grade_calc

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -6,7 +6,7 @@ IMPORTANT INFO:
 
 """
 
-from Logic import calc,grade_calc as gc,login, notes,user
+from Logic import average_grade_calc as gc, calc,login, notes,user
 from Logic.Clock import interface as ci
 import sys
 


### PR DESCRIPTION
# Conclusion

1. Renamed `grade_calc.py` to `average_grade_calc` to make the purpose of the file more clear
2. Updated the imports that use `grade_calc` to use `average_grade_calc`